### PR TITLE
Mysqlへの文字コード設定を適切に修正

### DIFF
--- a/ruby/base.rb
+++ b/ruby/base.rb
@@ -12,7 +12,7 @@ module Model
       config["db"]["user"],
       config["db"]["password"],
       config["db"]["name"])
-    @@db.charset = "utf-8"
+    @@db.charset = "utf8"
   end
   def self.close
     @@db.close


### PR DESCRIPTION
文字コード設定として、"utf-8" は受け付けない。 "utf8" とする必要あり。
